### PR TITLE
Fix cleanup when temp folder missing

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -23,7 +23,8 @@ MIMETYPES = {
 
 
 def clean_temp_dir():
-    """Deletes all files in the temp directory."""
+    """Ensure the temp directory exists and remove all files inside it."""
+    os.makedirs(TEMP_DIR, exist_ok=True)
     for filename in os.listdir(TEMP_DIR):
         file_path = os.path.join(TEMP_DIR, filename)
         try:


### PR DESCRIPTION
## Summary
- ensure temp directory exists before cleanup

## Testing
- `python -m py_compile app/app.py`
- `python app/app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685516d20d1c832e9c37671b8f11dcf5