### PR TITLE
Fix Gunicorn app module path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 EXPOSE 8000
-CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8000", "app:app"]
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8000", "wsgi:app"]

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,4 @@
+from app.app import app
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
## Summary
- add `wsgi.py` to expose the Flask app for Gunicorn
- update Dockerfile to run `wsgi:app` instead of `app:app`

## Testing
- `python3 -m py_compile app/app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_685516ba5df0832e949cb7d81732d7b8