### PR TITLE
Fix send_file path and adjust Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV PATH="$VENV_PATH/bin:$PATH"
 RUN pip install --upgrade pip setuptools wheel
 
 WORKDIR /app
+ENV PORT=8000
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/app/app.py
+++ b/app/app.py
@@ -7,7 +7,11 @@ import os
 app = Flask(__name__)
 flask_cors.CORS(app)
 
-TEMP_DIR = 'temp'
+# Directory where temporary compilation files will be stored.  Use an absolute
+# path so Flask can reliably locate the generated output regardless of the
+# current working directory.
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+TEMP_DIR = os.path.join(BASE_DIR, 'temp')
 MIMETYPES = {
     'pdf': 'application/pdf',
     'html': 'text/html',
@@ -146,7 +150,7 @@ def api():
             return jsonify({"error": f"File generation failed ({path} does not exist.)"}), 500
 
         return send_file(
-            fr'.\temp\{hashed}.{format}',
+            path,
             mimetype=MIMETYPES.get(format, 'application/octet-stream'),
             as_attachment=True,
             download_name=f"{name}.{format}"


### PR DESCRIPTION
## Summary
- ensure temporary files use an absolute path
- send compiled output using that path
- set a default `PORT` environment variable in the Dockerfile

## Testing
- `pip install -q -r requirements.txt && python -m py_compile app/app.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_6855290af8b8832ea881d3741e8e9aab